### PR TITLE
Implement carroceria management with full details

### DIFF
--- a/app/Http/Controllers/CarroceriaController.php
+++ b/app/Http/Controllers/CarroceriaController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Carroceria;
+use App\Services\CarroceriaService;
+use Illuminate\Http\Request;
+
+class CarroceriaController extends Controller
+{
+    protected $carroceriaService;
+
+    public function __construct(CarroceriaService $carroceriaService)
+    {
+        $this->carroceriaService = $carroceriaService;
+    }
+
+    public function index()
+    {
+        $carrocerias = Carroceria::all();
+        return view('carrocerias.index', compact('carrocerias'));
+    }
+
+    public function create()
+    {
+        return view('carrocerias.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'descricao' => 'required|string|max:255',
+            'chassi' => 'required|string|max:255|unique:carrocerias,chassi',
+            'placa' => 'required|string|max:8|unique:carrocerias,placa',
+            'peso_suportado' => 'required|numeric',
+            'status' => 'required|boolean'
+        ]);
+
+        $carroceria = $this->carroceriaService->store($validated);
+
+        return redirect()->route('carrocerias.index');
+    }
+
+    public function edit(Carroceria $carroceria)
+    {
+        return view('carrocerias.edit', compact('carroceria'));
+    }
+
+    public function update(Request $request, Carroceria $carroceria)
+    {
+        $validated = $request->validate([
+            'descricao' => 'required|string|max:255',
+            'chassi' => 'required|string|max:255|unique:carrocerias,chassi,' . $carroceria->id,
+            'placa' => 'required|string|max:8|unique:carrocerias,placa,' . $carroceria->id,
+            'peso_suportado' => 'required|numeric',
+            'status' => 'required|boolean'
+        ]);
+
+        $this->carroceriaService->update($carroceria, $validated);
+
+        return redirect()->route('carrocerias.index');
+    }
+
+    public function destroy(Carroceria $carroceria)
+    {
+        $carroceria->delete();
+        return response()->json(['success' => true]);
+    }
+}

--- a/app/Http/Requests/Delivery/StoreDeliveryRequest.php
+++ b/app/Http/Requests/Delivery/StoreDeliveryRequest.php
@@ -14,7 +14,11 @@ class StoreDeliveryRequest extends FormRequest
     public function rules()
     {
         return [
-            'route_id' => 'required|exists:routes,id'
+            'route_id' => 'required|exists:routes,id',
+            'driver_id' => 'required|exists:drivers,id',
+            'truck_id' => 'required|exists:trucks,id',
+            'carroceria_ids' => 'required|array|min:1',
+            'carroceria_ids.*' => 'exists:carrocerias,id'
         ];
     }
 
@@ -22,7 +26,13 @@ class StoreDeliveryRequest extends FormRequest
     {
         return [
             'route_id.required' => 'A rota é obrigatória',
-            'route_id.exists' => 'A rota selecionada não existe'
+            'route_id.exists' => 'A rota selecionada não existe',
+            'driver_id.required' => 'O motorista é obrigatório',
+            'driver_id.exists' => 'Motorista inválido',
+            'truck_id.required' => 'O caminhão é obrigatório',
+            'truck_id.exists' => 'Caminhão inválido',
+            'carroceria_ids.required' => 'É necessário selecionar ao menos uma carroceria',
+            'carroceria_ids.*.exists' => 'Carroceria inválida'
         ];
     }
 } 

--- a/app/Http/Resources/DeliveryResource.php
+++ b/app/Http/Resources/DeliveryResource.php
@@ -13,13 +13,32 @@ class DeliveryResource extends JsonResource
             'status' => $this->status,
             'start_date' => $this->start_date?->format('d/m/Y H:i'),
             'end_date' => $this->end_date?->format('d/m/Y H:i'),
+            'driver' => $this->driver ? [
+                'id' => $this->driver->id,
+                'name' => $this->driver->name,
+            ] : null,
+            'truck' => $this->truck ? [
+                'id' => $this->truck->id,
+                'marca' => $this->truck->marca,
+                'modelo' => $this->truck->modelo,
+            ] : null,
+            'carrocerias' => $this->carrocerias->map(function($c){
+                return [
+                    'id' => $c->id,
+                    'descricao' => $c->descricao,
+                    'chassi' => $c->chassi,
+                    'placa' => $c->placa,
+                    'peso_suportado' => $c->peso_suportado,
+                ];
+            }),
+            'current_stop' => $this->currentStop ? [
+                'id' => $this->currentStop->id,
+                'order' => $this->currentStop->order,
+                'name' => $this->currentStop->routeStop->name,
+            ] : null,
             'route' => [
                 'id' => $this->route->id,
                 'name' => $this->route->name,
-                'driver' => [
-                    'id' => $this->route->driver->id,
-                    'name' => $this->route->driver->name,
-                ],
                 'stops' => $this->route->stops->map(function($stop) {
                     return [
                         'name' => $stop->name,
@@ -33,4 +52,5 @@ class DeliveryResource extends JsonResource
             ]
         ];
     }
-} 
+}
+

--- a/app/Models/Carroceria.php
+++ b/app/Models/Carroceria.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Carroceria extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'descricao',
+        'chassi',
+        'placa',
+        'peso_suportado',
+        'status'
+    ];
+
+    public function deliveries()
+    {
+        return $this->hasMany(Delivery::class);
+    }
+}

--- a/app/Models/Delivery.php
+++ b/app/Models/Delivery.php
@@ -4,6 +4,9 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Models\Carroceria;
+use App\Models\DeliveryStop;
+use App\Models\DeliveryHistory;
 
 class Delivery extends Model
 {
@@ -14,6 +17,7 @@ class Delivery extends Model
         'driver_id',
         'truck_id',
         'trailer_id',
+        'current_delivery_stop_id',
         'status',
         'start_date',
         'end_date',
@@ -43,5 +47,25 @@ class Delivery extends Model
     public function trailer()
     {
         return $this->belongsTo(Trailer::class);
+    }
+
+    public function carrocerias()
+    {
+        return $this->belongsToMany(Carroceria::class);
+    }
+
+    public function deliveryStops()
+    {
+        return $this->hasMany(DeliveryStop::class);
+    }
+
+    public function currentStop()
+    {
+        return $this->belongsTo(DeliveryStop::class, 'current_delivery_stop_id');
+    }
+
+    public function histories()
+    {
+        return $this->hasMany(DeliveryHistory::class);
     }
 }

--- a/app/Models/DeliveryHistory.php
+++ b/app/Models/DeliveryHistory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DeliveryHistory extends Model
+{
+    protected $fillable = [
+        'delivery_id',
+        'delivery_stop_id',
+        'driver_id',
+        'truck_id',
+        'carroceria_ids',
+    ];
+
+    protected $casts = [
+        'carroceria_ids' => 'array',
+    ];
+
+    public function delivery()
+    {
+        return $this->belongsTo(Delivery::class);
+    }
+
+    public function deliveryStop()
+    {
+        return $this->belongsTo(DeliveryStop::class);
+    }
+}

--- a/app/Models/DeliveryStop.php
+++ b/app/Models/DeliveryStop.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DeliveryStop extends Model
+{
+    protected $fillable = [
+        'delivery_id',
+        'route_stop_id',
+        'order',
+        'status',
+        'completed_at',
+    ];
+
+    protected $casts = [
+        'completed_at' => 'datetime',
+    ];
+
+    public function delivery()
+    {
+        return $this->belongsTo(Delivery::class);
+    }
+
+    public function routeStop()
+    {
+        return $this->belongsTo(RouteStop::class);
+    }
+}

--- a/app/Models/Route.php
+++ b/app/Models/Route.php
@@ -12,8 +12,6 @@ class Route extends Model
     protected $fillable = [
         'name',
         'start_date',
-        'driver_id',
-        'truck_id',
         'current_mileage',
         'status'
     ];
@@ -24,15 +22,6 @@ class Route extends Model
     ];
 
     // Relacionamentos
-    public function driver()
-    {
-        return $this->belongsTo(Driver::class);
-    }
-
-    public function truck()
-    {
-        return $this->belongsTo(Truck::class);
-    }
 
     public function addresses()
     {

--- a/app/Services/CarroceriaService.php
+++ b/app/Services/CarroceriaService.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Carroceria;
+
+class CarroceriaService
+{
+    public function store(array $data)
+    {
+        return Carroceria::create($data);
+    }
+
+    public function update(Carroceria $carroceria, array $data)
+    {
+        return $carroceria->update($data);
+    }
+}

--- a/app/Services/RouteService.php
+++ b/app/Services/RouteService.php
@@ -25,8 +25,6 @@ class RouteService
                 [
                     'name' => $data['name'],
                     'start_date' => $data['start_date'],
-                    'driver_id' => $data['driver_id'],
-                    'truck_id' => $data['truck_id'],
                     'current_mileage' => $data['current_mileage'],
                     'status' => 'draft'
                 ]

--- a/database/migrations/2025_06_09_000000_create_carrocerias_table.php
+++ b/database/migrations/2025_06_09_000000_create_carrocerias_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('carrocerias', function (Blueprint $table) {
+            $table->id();
+            $table->string('descricao');
+            $table->string('chassi')->unique();
+            $table->string('placa', 8)->unique();
+            $table->decimal('peso_suportado', 10, 2);
+            $table->boolean('status')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('carrocerias');
+    }
+};

--- a/database/migrations/2025_06_09_000100_add_carroceria_to_deliveries.php
+++ b/database/migrations/2025_06_09_000100_add_carroceria_to_deliveries.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('deliveries', function (Blueprint $table) {
+            $table->foreignId('carroceria_id')->nullable()->constrained('carrocerias');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('deliveries', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('carroceria_id');
+        });
+    }
+};

--- a/database/migrations/2025_06_09_000200_remove_driver_truck_from_routes.php
+++ b/database/migrations/2025_06_09_000200_remove_driver_truck_from_routes.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('routes', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('driver_id');
+            $table->dropConstrainedForeignId('truck_id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('routes', function (Blueprint $table) {
+            $table->foreignId('driver_id')->nullable()->constrained('drivers');
+            $table->foreignId('truck_id')->nullable()->constrained('trucks');
+        });
+    }
+};

--- a/database/migrations/2025_06_09_000300_create_delivery_stops_table.php
+++ b/database/migrations/2025_06_09_000300_create_delivery_stops_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('delivery_stops', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('delivery_id')->constrained('deliveries');
+            $table->foreignId('route_stop_id')->constrained('route_stops');
+            $table->integer('order');
+            $table->enum('status', ['pending','completed'])->default('pending');
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('delivery_stops');
+    }
+};

--- a/database/migrations/2025_06_09_000400_add_current_stop_to_deliveries.php
+++ b/database/migrations/2025_06_09_000400_add_current_stop_to_deliveries.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('deliveries', function (Blueprint $table) {
+            $table->foreignId('current_delivery_stop_id')->nullable()->constrained('delivery_stops');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('deliveries', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('current_delivery_stop_id');
+        });
+    }
+};

--- a/database/migrations/2025_06_09_000500_create_delivery_histories_table.php
+++ b/database/migrations/2025_06_09_000500_create_delivery_histories_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('delivery_histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('delivery_id')->constrained('deliveries');
+            $table->foreignId('delivery_stop_id')->nullable()->constrained('delivery_stops');
+            $table->foreignId('driver_id')->nullable()->constrained('drivers');
+            $table->foreignId('truck_id')->nullable()->constrained('trucks');
+            $table->json('carroceria_ids')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('delivery_histories');
+    }
+};

--- a/database/migrations/2025_06_09_000600_create_carroceria_delivery_table.php
+++ b/database/migrations/2025_06_09_000600_create_carroceria_delivery_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('carroceria_delivery', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('delivery_id')->constrained('deliveries');
+            $table->foreignId('carroceria_id')->constrained('carrocerias');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('carroceria_delivery');
+    }
+};

--- a/resources/views/carrocerias/create.blade.php
+++ b/resources/views/carrocerias/create.blade.php
@@ -1,0 +1,35 @@
+@extends('layout.master')
+
+@section('content')
+<div class="h-full flex flex-col">
+  <div class="bg-white rounded-lg shadow-sm p-6">
+    <form action="{{ route('carrocerias.store') }}" method="POST">
+      @csrf
+      <div class="mb-4">
+        <label for="descricao" class="block text-sm font-medium text-gray-700 mb-2">Descrição</label>
+        <input type="text" name="descricao" id="descricao" class="w-full h-12 px-4 rounded-lg border-gray-300" required>
+      </div>
+      <div class="mb-4">
+        <label for="chassi" class="block text-sm font-medium text-gray-700 mb-2">Chassi</label>
+        <input type="text" name="chassi" id="chassi" class="w-full h-12 px-4 rounded-lg border-gray-300" required>
+      </div>
+      <div class="mb-4">
+        <label for="placa" class="block text-sm font-medium text-gray-700 mb-2">Placa</label>
+        <input type="text" name="placa" id="placa" class="w-full h-12 px-4 rounded-lg border-gray-300 uppercase" required>
+      </div>
+      <div class="mb-4">
+        <label for="peso_suportado" class="block text-sm font-medium text-gray-700 mb-2">Peso Suportado (kg)</label>
+        <input type="number" step="0.01" name="peso_suportado" id="peso_suportado" class="w-full h-12 px-4 rounded-lg border-gray-300" required>
+      </div>
+      <div class="mb-4">
+        <label for="status" class="block text-sm font-medium text-gray-700 mb-2">Status</label>
+        <select name="status" id="status" class="w-full h-12 px-4 rounded-lg border-gray-300">
+          <option value="1">Ativa</option>
+          <option value="0">Inativa</option>
+        </select>
+      </div>
+      <button type="submit" class="px-4 py-2 bg-gray-900 text-white rounded-lg">Salvar</button>
+    </form>
+  </div>
+</div>
+@endsection

--- a/resources/views/carrocerias/edit.blade.php
+++ b/resources/views/carrocerias/edit.blade.php
@@ -1,0 +1,36 @@
+@extends('layout.master')
+
+@section('content')
+<div class="h-full flex flex-col">
+  <div class="bg-white rounded-lg shadow-sm p-6">
+    <form action="{{ route('carrocerias.update', $carroceria) }}" method="POST">
+      @csrf
+      @method('PUT')
+      <div class="mb-4">
+        <label for="descricao" class="block text-sm font-medium text-gray-700 mb-2">Descrição</label>
+        <input type="text" name="descricao" id="descricao" value="{{ $carroceria->descricao }}" class="w-full h-12 px-4 rounded-lg border-gray-300" required>
+      </div>
+      <div class="mb-4">
+        <label for="chassi" class="block text-sm font-medium text-gray-700 mb-2">Chassi</label>
+        <input type="text" name="chassi" id="chassi" value="{{ $carroceria->chassi }}" class="w-full h-12 px-4 rounded-lg border-gray-300" required>
+      </div>
+      <div class="mb-4">
+        <label for="placa" class="block text-sm font-medium text-gray-700 mb-2">Placa</label>
+        <input type="text" name="placa" id="placa" value="{{ $carroceria->placa }}" class="w-full h-12 px-4 rounded-lg border-gray-300 uppercase" required>
+      </div>
+      <div class="mb-4">
+        <label for="peso_suportado" class="block text-sm font-medium text-gray-700 mb-2">Peso Suportado (kg)</label>
+        <input type="number" step="0.01" name="peso_suportado" id="peso_suportado" value="{{ $carroceria->peso_suportado }}" class="w-full h-12 px-4 rounded-lg border-gray-300" required>
+      </div>
+      <div class="mb-4">
+        <label for="status" class="block text-sm font-medium text-gray-700 mb-2">Status</label>
+        <select name="status" id="status" class="w-full h-12 px-4 rounded-lg border-gray-300">
+          <option value="1" {{ $carroceria->status ? 'selected' : '' }}>Ativa</option>
+          <option value="0" {{ !$carroceria->status ? 'selected' : '' }}>Inativa</option>
+        </select>
+      </div>
+      <button type="submit" class="px-4 py-2 bg-gray-900 text-white rounded-lg">Salvar</button>
+    </form>
+  </div>
+</div>
+@endsection

--- a/resources/views/carrocerias/index.blade.php
+++ b/resources/views/carrocerias/index.blade.php
@@ -1,0 +1,43 @@
+@extends('layout.master')
+
+@section('content')
+<div class="h-full flex flex-col">
+  <div class="flex justify-between items-center mb-6">
+    <div>
+      <h1 class="text-xl font-semibold text-gray-900">Carrocerias</h1>
+    </div>
+    <a href="{{ route('carrocerias.create') }}" class="px-4 py-2 bg-gray-900 text-white rounded-lg">Adicionar</a>
+  </div>
+
+  <div class="bg-white rounded-lg shadow-sm">
+    <div class="p-6">
+      <table class="w-full text-sm text-left">
+        <thead class="bg-gray-50 text-xs uppercase">
+          <tr>
+            <th class="px-6 py-3">Descrição</th>
+            <th class="px-6 py-3">Chassi</th>
+            <th class="px-6 py-3">Placa</th>
+            <th class="px-6 py-3">Peso Suportado</th>
+            <th class="px-6 py-3">Status</th>
+            <th class="px-6 py-3 text-right">Ações</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100">
+          @foreach($carrocerias as $carroceria)
+          <tr>
+            <td class="px-6 py-4">{{ $carroceria->descricao }}</td>
+            <td class="px-6 py-4">{{ $carroceria->chassi }}</td>
+            <td class="px-6 py-4">{{ $carroceria->placa }}</td>
+            <td class="px-6 py-4">{{ $carroceria->peso_suportado }}</td>
+            <td class="px-6 py-4">{{ $carroceria->status ? 'Ativa' : 'Inativa' }}</td>
+            <td class="px-6 py-4 text-right">
+              <a href="{{ route('carrocerias.edit', $carroceria) }}" class="text-blue-600">Editar</a>
+            </td>
+          </tr>
+          @endforeach
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/deliveries/create.blade.php
+++ b/resources/views/deliveries/create.blade.php
@@ -10,12 +10,38 @@
                 </div>
                 <div class="card-body">
                     <form id="createDeliveryForm">
-                        <div class="form-group">
+                        <div class="form-group mb-4">
                             <label for="route_id">Rota</label>
                             <select class="form-control" id="route_id" name="route_id" required>
                                 <option value="">Selecione uma rota</option>
                                 @foreach($availableRoutes as $route)
                                     <option value="{{ $route->id }}">{{ $route->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="form-group mb-4">
+                            <label for="driver_id">Motorista</label>
+                            <select class="form-control" id="driver_id" name="driver_id" required>
+                                <option value="">Selecione</option>
+                                @foreach($drivers as $driver)
+                                    <option value="{{ $driver->id }}">{{ $driver->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="form-group mb-4">
+                            <label for="truck_id">Caminhão</label>
+                            <select class="form-control" id="truck_id" name="truck_id" required>
+                                <option value="">Selecione</option>
+                                @foreach($trucks as $truck)
+                                    <option value="{{ $truck->id }}">{{ $truck->marca }} - {{ $truck->modelo }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="form-group mb-4">
+                            <label for="carroceria_ids">Carrocerias</label>
+                            <select multiple class="form-control" id="carroceria_ids" name="carroceria_ids[]" required>
+                                @foreach($carrocerias as $carroceria)
+                                    <option value="{{ $carroceria->id }}">{{ $carroceria->descricao }}</option>
                                 @endforeach
                             </select>
                         </div>

--- a/resources/views/deliveries/index.blade.php
+++ b/resources/views/deliveries/index.blade.php
@@ -76,7 +76,7 @@
             <tr class="hover:bg-gray-50">
               <td class="px-6 py-4 text-gray-600">{{ $delivery->id }}</td>
               <td class="px-6 py-4 text-gray-900">{{ optional($delivery->route)->name ?? 'Rota Excluída' }}</td>
-              <td class="px-6 py-4 text-gray-600">{{ optional(optional($delivery->route)->driver)->name ?? 'Motorista não encontrado' }}</td>
+              <td class="px-6 py-4 text-gray-600">{{ optional($delivery->driver)->name ?? 'Motorista não encontrado' }}</td>
               <td class="px-6 py-4 text-gray-600">{{ $delivery->start_date?->format('d/m/Y') }}</td>
               <td class="px-6 py-4 text-gray-600">{{ $delivery->end_date?->format('d/m/Y') }}</td>
               <td class="px-6 py-4">
@@ -165,7 +165,7 @@
             <select id="route_id" name="route_id" class="w-full rounded-lg border-gray-300 focus:ring-blue-500 focus:border-blue-500" required>
               <option value="">Selecione uma rota</option>
               @foreach($availableRoutes as $route)
-                <option value="{{ $route->id }}">{{ $route->name }} - {{ optional($route->driver)->name ?? 'Motorista não encontrado' }}</option>
+                <option value="{{ $route->id }}">{{ $route->name }}</option>
               @endforeach
             </select>
           </div>
@@ -424,7 +424,7 @@ async function viewDeliveryDetails(deliveryId) {
                     <span class="font-medium">Nome da Rota:</span> ${data.data.route ? data.data.route.name : 'Rota Excluída'}
                 </div>
                 <div>
-                    <span class="font-medium">Motorista:</span> ${data.data.route && data.data.route.driver ? data.data.route.driver.name : 'Motorista não encontrado'}
+                    <span class="font-medium">Motorista:</span> ${data.data.driver ? data.data.driver.name : 'Motorista não encontrado'}
                 </div>
                 <div>
                     <span class="font-medium">Data Início:</span> ${data.data.start_date || 'N/A'}

--- a/resources/views/layout/sidebar.blade.php
+++ b/resources/views/layout/sidebar.blade.php
@@ -66,6 +66,9 @@
                <li>
                   <a href="{{ route('trucks.index') }}" class="flex items-center w-full p-2 text-gray-900 transition duration-75 rounded-lg pl-11 group hover:bg-gray-100">Caminhões</a>
                </li>
+               <li>
+                  <a href="{{ route('carrocerias.index') }}" class="flex items-center w-full p-2 text-gray-900 transition duration-75 rounded-lg pl-11 group hover:bg-gray-100">Carrocerias</a>
+               </li>
             </ul>
          </li>
 

--- a/resources/views/routes/index.blade.php
+++ b/resources/views/routes/index.blade.php
@@ -87,8 +87,6 @@
             <tr>
               <th class="px-6 py-3 text-gray-600 font-medium">CÓD.</th>
               <th class="px-6 py-3 text-gray-600 font-medium">NOME</th>
-              <th class="px-6 py-3 text-gray-600 font-medium">MOTORISTA</th>
-              <th class="px-6 py-3 text-gray-600 font-medium">CAMINHÃO</th>
               <th class="px-6 py-3 text-gray-600 font-medium">DATA INÍCIO</th>
               <th class="px-6 py-3 text-gray-600 font-medium">STATUS</th>
               <th class="px-6 py-3 text-gray-600 font-medium text-right">AÇÕES</th>
@@ -99,12 +97,6 @@
             <tr class="hover:bg-gray-50">
               <td class="px-6 py-4 text-gray-600">{{ $route->id }}</td>
               <td class="px-6 py-4 text-gray-900">{{ $route->name }}</td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                {{ $route->driver->name ?? 'N/A' }}
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                {{ $route->truck->marca }} {{ $route->truck->modelo }} - {{ $route->truck->placa }}
-              </td>
               <td class="px-6 py-4 text-gray-600">{{ $route->start_date->format('d/m/Y') }}</td>
               <td class="px-6 py-4">
                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium 

--- a/resources/views/routes/partials/step1.blade.php
+++ b/resources/views/routes/partials/step1.blade.php
@@ -3,23 +3,14 @@
     <div class="grid grid-cols-2 gap-6">
         <div>
             <label for="name" class="block text-sm font-medium text-gray-700 mb-2">Nome</label>
-            <input type="text" 
-                   id="name" 
-                   name="name" 
-                   value="{{ old('name', $route->name ?? '') }}"
-                   class="w-full h-12 px-4 rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
-                   placeholder="Digite o nome da rota">
+            <input type="text" id="name" name="name" value="{{ old('name', $route->name ?? '') }}" class="w-full h-12 px-4 rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500" placeholder="Digite o nome da rota">
             @error('name')
                 <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
             @enderror
         </div>
         <div>
             <label for="start_date" class="block text-sm font-medium text-gray-700 mb-2">Data Início</label>
-            <input type="date" 
-                   id="start_date" 
-                   name="start_date" 
-                   value="{{ old('start_date', isset($route->start_date) ? $route->start_date->format('Y-m-d') : '') }}"
-                   class="w-full h-12 px-4 rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500">
+            <input type="date" id="start_date" name="start_date" value="{{ old('start_date', isset($route->start_date) ? $route->start_date->format('Y-m-d') : '') }}" class="w-full h-12 px-4 rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500">
             @error('start_date')
                 <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
             @enderror
@@ -27,191 +18,14 @@
     </div>
 </div>
 
-<!-- Informações do Motorista -->
 <div class="mb-8">
-    <h3 class="text-lg font-medium text-gray-900 mb-6">Informações do motorista</h3>
-    <div class="grid grid-cols-4 gap-6">
-        <div>
-            <label for="driver_id" class="block text-sm font-medium text-gray-700 mb-2">Motorista</label>
-            <select id="driver_id" 
-                    name="driver_id" 
-                    class="w-full h-12 px-4 rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500">
-                <option value="">Selecione um motorista</option>
-                @foreach($drivers as $driver)
-                    <option value="{{ $driver->id }}" 
-                            data-cpf="{{ $driver->cpf }}"
-                            data-phone="{{ $driver->phone }}"
-                            data-email="{{ $driver->email }}"
-                            {{ old('driver_id', $route->driver_id ?? '') == $driver->id ? 'selected' : '' }}>
-                        {{ $driver->name }}
-                    </option>
-                @endforeach
-            </select>
-            @error('driver_id')
-                <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
-            @enderror
-        </div>
-        <div>
-            <label for="driver_cpf" class="block text-sm font-medium text-gray-700 mb-2">CPF</label>
-            <input type="text" id="driver_cpf" class="w-full h-12 px-4 rounded-lg bg-gray-50 border-gray-300" readonly>
-        </div>
-        <div>
-            <label for="driver_phone" class="block text-sm font-medium text-gray-700 mb-2">Telefone</label>
-            <input type="text" id="driver_phone" class="w-full h-12 px-4 rounded-lg bg-gray-50 border-gray-300" readonly>
-        </div>
-        <div>
-            <label for="driver_email" class="block text-sm font-medium text-gray-700 mb-2">E-mail</label>
-            <input type="email" id="driver_email" class="w-full h-12 px-4 rounded-lg bg-gray-50 border-gray-300" readonly>
-        </div>
-    </div>
-</div>
-
-<!-- Informações do Caminhão -->
-<div class="mb-8">
-    <h3 class="text-lg font-medium text-gray-900 mb-6">Informações do caminhão</h3>
-    <div class="grid grid-cols-4 gap-6 mb-6">
-        <div>
-            <label for="truck_id" class="block text-sm font-medium text-gray-700 mb-2">Caminhão</label>
-            <select id="truck_id" 
-                    name="truck_id" 
-                    class="w-full h-12 px-4 rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500">
-                <option value="">Selecione um caminhão</option>
-                @foreach($trucks as $truck)
-                    <option value="{{ $truck->id }}"
-                            data-cor="{{ $truck->cor }}"
-                            data-combustivel="{{ $truck->tipo_combustivel }}"
-                            data-modelo="{{ $truck->modelo }}"
-                            data-marca="{{ $truck->marca }}"
-                            data-chassi="{{ $truck->chassi }}"
-                            data-placa="{{ $truck->placa }}"
-                            data-quilometragem="{{ $truck->quilometragem }}"
-                            data-ultima_revisao="{{ $truck->ultima_revisao ? \Carbon\Carbon::parse($truck->ultima_revisao)->format('Y-m-d') : '' }}"
-                            {{ old('truck_id', $route->truck_id ?? '') == $truck->id ? 'selected' : '' }}>
-                        {{ $truck->marca }} - {{ $truck->modelo }} ({{ $truck->placa }})
-                    </option>
-                @endforeach
-            </select>
-            @error('truck_id')
-                <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
-            @enderror
-        </div>
-        <div>
-            <label for="truck_marca" class="block text-sm font-medium text-gray-700 mb-2">Marca</label>
-            <input type="text" id="truck_marca" class="w-full h-12 px-4 rounded-lg bg-gray-50 border-gray-300" readonly>
-        </div>
-        <div>
-            <label for="truck_modelo" class="block text-sm font-medium text-gray-700 mb-2">Modelo</label>
-            <input type="text" id="truck_modelo" class="w-full h-12 px-4 rounded-lg bg-gray-50 border-gray-300" readonly>
-        </div>
-        <div>
-            <label for="truck_cor" class="block text-sm font-medium text-gray-700 mb-2">Cor</label>
-            <input type="text" id="truck_cor" class="w-full h-12 px-4 rounded-lg bg-gray-50 border-gray-300" readonly>
-        </div>
-    </div>
-    <div class="grid grid-cols-4 gap-6 mb-6">
-        <div>
-            <label for="truck_combustivel" class="block text-sm font-medium text-gray-700 mb-2">Combustível</label>
-            <input type="text" id="truck_combustivel" class="w-full h-12 px-4 rounded-lg bg-gray-50 border-gray-300" readonly>
-        </div>
-        <div>
-            <label for="truck_chassi" class="block text-sm font-medium text-gray-700 mb-2">Chassi</label>
-            <input type="text" id="truck_chassi" class="w-full h-12 px-4 rounded-lg bg-gray-50 border-gray-300" readonly>
-        </div>
-        <div>
-            <label for="truck_placa" class="block text-sm font-medium text-gray-700 mb-2">Placa</label>
-            <input type="text" id="truck_placa" class="w-full h-12 px-4 rounded-lg bg-gray-50 border-gray-300" readonly>
-        </div>
+    <div class="grid grid-cols-2 gap-6">
         <div>
             <label for="current_mileage" class="block text-sm font-medium text-gray-700 mb-2">Quilometragem Atual</label>
-            <input type="number" 
-                   step="0.01" 
-                   id="current_mileage" 
-                   name="current_mileage" 
-                   value="{{ old('current_mileage', $route->current_mileage ?? '') }}"
-                   class="w-full h-12 px-4 rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500">
+            <input type="number" step="0.01" id="current_mileage" name="current_mileage" value="{{ old('current_mileage', $route->current_mileage ?? '') }}" class="w-full h-12 px-4 rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500">
             @error('current_mileage')
                 <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
             @enderror
         </div>
     </div>
-    <div class="grid grid-cols-4 gap-6">
-        <div>
-            <label for="truck_quilometragem" class="block text-sm font-medium text-gray-700 mb-2">Quilometragem do Caminhão</label>
-            <input type="text" id="truck_quilometragem" class="w-full h-12 px-4 rounded-lg bg-gray-50 border-gray-300" readonly>
-        </div>
-        <div>
-            <label for="truck_ultima_revisao" class="block text-sm font-medium text-gray-700 mb-2">Última Revisão</label>
-            <input type="date" id="truck_ultima_revisao" class="w-full h-12 px-4 rounded-lg bg-gray-50 border-gray-300" readonly>
-        </div>
-    </div>
 </div>
-
-@push('custom-scripts')
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    // Atualiza informações do motorista
-    const driverSelect = document.getElementById('driver_id');
-    const updateDriverInfo = () => {
-        const selectedOption = driverSelect.options[driverSelect.selectedIndex];
-        document.getElementById('driver_cpf').value = selectedOption.dataset.cpf || '';
-        document.getElementById('driver_phone').value = selectedOption.dataset.phone || '';
-        document.getElementById('driver_email').value = selectedOption.dataset.email || '';
-    };
-    driverSelect.addEventListener('change', updateDriverInfo);
-    updateDriverInfo(); // Executa na carga inicial
-
-    // Atualiza informações do caminhão
-    const truckSelect = document.getElementById('truck_id');
-    const updateTruckInfo = () => {
-        const selectedOption = truckSelect.options[truckSelect.selectedIndex];
-        document.getElementById('truck_marca').value = selectedOption.dataset.marca || '';
-        document.getElementById('truck_modelo').value = selectedOption.dataset.modelo || '';
-        document.getElementById('truck_cor').value = selectedOption.dataset.cor || '';
-        document.getElementById('truck_combustivel').value = selectedOption.dataset.combustivel || '';
-        document.getElementById('truck_chassi').value = selectedOption.dataset.chassi || '';
-        document.getElementById('truck_placa').value = selectedOption.dataset.placa || '';
-        document.getElementById('truck_quilometragem').value = selectedOption.dataset.quilometragem || '';
-        document.getElementById('truck_ultima_revisao').value = selectedOption.dataset.ultima_revisao || '';
-        
-        // Preenche a quilometragem atual com a quilometragem do caminhão se estiver vazia
-        const currentMileageInput = document.getElementById('current_mileage');
-        if (!currentMileageInput.value) {
-            currentMileageInput.value = selectedOption.dataset.quilometragem || '';
-        }
-    };
-    truckSelect.addEventListener('change', updateTruckInfo);
-    updateTruckInfo(); // Executa na carga inicial
-
-    // Adiciona handler para o formulário
-    const form = document.querySelector('form');
-    form.addEventListener('submit', async function(e) {
-        e.preventDefault();
-        
-        try {
-            const formData = new FormData(form);
-            formData.append('step', '1'); // Indica que estamos na etapa 1
-
-            const response = await fetch(form.action, {
-                method: 'POST',
-                body: formData,
-                headers: {
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-                    'Accept': 'application/json'
-                }
-            });
-
-            const data = await response.json();
-
-            if (data.success) {
-                // Se salvou com sucesso, redireciona para a próxima etapa
-                window.location.href = `${window.location.pathname}?step=2&route_id=${data.route_id}`;
-            } else {
-                throw new Error(data.message || 'Erro ao salvar os dados');
-            }
-        } catch (error) {
-            alert('Erro ao salvar: ' + error.message);
-        }
-    });
-});
-</script>
-@endpush 

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\DriverController;
 use App\Http\Controllers\TruckController;
 use App\Http\Controllers\RouteController;
 use App\Http\Controllers\DeliveryController;
+use App\Http\Controllers\CarroceriaController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\PermissionController;
 
@@ -165,11 +166,16 @@ Route::middleware(['auth'])->group(function () {
 
     // Mova estas rotas ANTES da rota catch-all 404
     Route::resource('trucks', TruckController::class);
+    Route::resource('carrocerias', CarroceriaController::class);
     Route::resource('routes', RouteController::class);
     Route::post('routes/{route}/optimize', [RouteController::class, 'optimize'])->name('routes.optimize');
     Route::resource('deliveries', DeliveryController::class);
     Route::post('deliveries/{delivery}/complete', [DeliveryController::class, 'complete'])
         ->name('deliveries.complete');
+    Route::post('deliveries/{delivery}/change-resources', [DeliveryController::class, 'changeResources'])->name('deliveries.change-resources');
+    Route::post('deliveries/{delivery}/complete-stop', [DeliveryController::class, 'completeStop'])->name('deliveries.complete-stop');
+    Route::post('deliveries/{delivery}/cancel', [DeliveryController::class, 'cancel'])->name('deliveries.cancel');
+    Route::get('deliveries/{delivery}/history', [DeliveryController::class, 'history'])->name('deliveries.history');
     Route::get('deliveries/{delivery}/details', [DeliveryController::class, 'details'])
         ->name('deliveries.details');
     Route::post('deliveries/{delivery}/reuse', [DeliveryController::class, 'reuse'])

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -16,6 +16,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertRedirect('/login');
     }
 }


### PR DESCRIPTION
## Summary
- extend carroceria table with chassi, placa and peso suportado
- allow managing carroceria status and details via controller and views
- show carroceria menu with trucks and drivers
- expose carroceria fields in delivery resource
- adjust example test to expect login redirect
- add delivery resource management and tracking

## Testing
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68476779489c8330926973fce8690bb6