### PR TITLE
Implement delivery history view and fix stop update request

### DIFF
--- a/app/Http/Controllers/DeliveryController.php
+++ b/app/Http/Controllers/DeliveryController.php
@@ -502,4 +502,10 @@ class DeliveryController extends Controller
             ], 422);
         }
     }
+
+    public function historyView(Delivery $delivery)
+    {
+        $delivery->load(['deliveryRoute', 'deliveryDriver', 'deliveryTruck']);
+        return view('deliveries.history', compact('delivery'));
+    }
 }

--- a/app/Models/DeliveryHistory.php
+++ b/app/Models/DeliveryHistory.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Driver;
+use App\Models\Truck;
 
 class DeliveryHistory extends Model
 {
@@ -26,5 +28,15 @@ class DeliveryHistory extends Model
     public function deliveryStop()
     {
         return $this->belongsTo(DeliveryStop::class);
+    }
+
+    public function driver()
+    {
+        return $this->belongsTo(Driver::class);
+    }
+
+    public function truck()
+    {
+        return $this->belongsTo(Truck::class);
     }
 }

--- a/app/Services/DeliveryService.php
+++ b/app/Services/DeliveryService.php
@@ -413,7 +413,10 @@ class DeliveryService
 
     public function getHistory(Delivery $delivery)
     {
-        return $delivery->histories()->with('deliveryStop.deliveryRouteStop')->orderBy('created_at')->get();
+        return $delivery->histories()
+            ->with(['deliveryStop.deliveryRouteStop', 'driver', 'truck'])
+            ->orderBy('created_at')
+            ->get();
     }
 
     public function reuseRoute(Delivery $delivery)

--- a/resources/views/deliveries/edit-stop.blade.php
+++ b/resources/views/deliveries/edit-stop.blade.php
@@ -153,10 +153,12 @@ document.addEventListener('DOMContentLoaded', function() {
     
     const photoUpload = new Dropzone("#photoUpload", {
         url: "{{ route('deliveries.update-stop', ['delivery' => $delivery->id, 'stop' => $stop->id]) }}",
+        method: 'post',
         paramName: "photos",
         maxFilesize: 2, // MB
         acceptedFiles: "image/*",
         addRemoveLinks: true,
+        params: { _method: 'PUT' },
         headers: {
             'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
         }
@@ -167,6 +169,7 @@ document.addEventListener('DOMContentLoaded', function() {
         e.preventDefault();
         
         const formData = new FormData(this);
+        formData.append('_method', 'PUT');
         
         // Adiciona as fotos do Dropzone
         const dropzoneFiles = photoUpload.getAcceptedFiles();

--- a/resources/views/deliveries/history.blade.php
+++ b/resources/views/deliveries/history.blade.php
@@ -1,0 +1,70 @@
+@extends('layout.master')
+
+@push('plugin-styles')
+  <link href="{{ asset('assets/plugins/sweetalert2/sweetalert2.min.css') }}" rel="stylesheet" />
+@endpush
+
+@section('content')
+<div class="page-content">
+    <div class="row">
+        <div class="col-md-12 grid-margin stretch-card">
+            <div class="card">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-4">
+                        <h6 class="card-title">Histórico da Entrega #{{ $delivery->id }}</h6>
+                        <a href="{{ route('deliveries.show', $delivery) }}" class="btn btn-sm btn-secondary">Voltar</a>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>Data</th>
+                                    <th>Parada</th>
+                                    <th>Motorista</th>
+                                    <th>Caminhão</th>
+                                    <th>Carrocerias</th>
+                                </tr>
+                            </thead>
+                            <tbody id="history-body"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('plugin-scripts')
+  <script src="{{ asset('assets/plugins/sweetalert2/sweetalert2.min.js') }}"></script>
+@endpush
+
+@push('custom-scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    fetch("{{ route('deliveries.history', $delivery) }}")
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                const body = document.getElementById('history-body');
+                data.data.forEach(entry => {
+                    const tr = document.createElement('tr');
+                    const stopName = entry.delivery_stop ? entry.delivery_stop.delivery_route_stop.name : '-';
+                    const carros = (entry.carroceria_ids || []).join(', ');
+                    tr.innerHTML = `<td>${new Date(entry.created_at).toLocaleString()}</td>` +
+                                   `<td>${stopName}</td>` +
+                                   `<td>${entry.driver ? entry.driver.name : entry.driver_id}</td>` +
+                                   `<td>${entry.truck ? entry.truck.placa : entry.truck_id}</td>` +
+                                   `<td>${carros}</td>`;
+                    body.appendChild(tr);
+                });
+            } else {
+                Swal.fire('Erro', 'Não foi possível carregar o histórico', 'error');
+            }
+        })
+        .catch(() => {
+            Swal.fire('Erro', 'Não foi possível carregar o histórico', 'error');
+        });
+});
+</script>
+@endpush

--- a/resources/views/deliveries/show.blade.php
+++ b/resources/views/deliveries/show.blade.php
@@ -140,9 +140,13 @@
         </div>
       </div>
 
-      <!-- Botão Voltar -->
-      <div class="mt-6 flex justify-end">
-        <a href="{{ route('deliveries.index') }}" 
+      <!-- Botões -->
+      <div class="mt-6 flex justify-end space-x-2">
+        <a href="{{ route('deliveries.history-view', $delivery) }}"
+           class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+          Histórico
+        </a>
+        <a href="{{ route('deliveries.index') }}"
            class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
           Voltar
         </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -178,6 +178,7 @@ Route::middleware(['web', 'auth'])->group(function () {
     Route::post('/deliveries/{delivery}/complete-stop', [DeliveryController::class, 'completeStop'])->name('deliveries.complete-stop');
     Route::post('deliveries/{delivery}/cancel', [DeliveryController::class, 'cancel'])->name('deliveries.cancel');
     Route::get('deliveries/{delivery}/history', [DeliveryController::class, 'history'])->name('deliveries.history');
+    Route::get('deliveries/{delivery}/history-view', [DeliveryController::class, 'historyView'])->name('deliveries.history-view');
     Route::get('deliveries/{delivery}/details', [DeliveryController::class, 'details'])
         ->name('deliveries.details');
     Route::post('deliveries/{delivery}/reuse', [DeliveryController::class, 'reuse'])


### PR DESCRIPTION
## Summary
- fix delivery stop update script to send PUT method
- add a new history page and link to it from the delivery details page
- expose controller method and route for the history view
- load driver and truck relationships when fetching history
- add driver/truck relations to `DeliveryHistory`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dabcfdf788330b5c63925105273dd